### PR TITLE
Rule for discouraging use of selectors within describe blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Rule                         | Default       | Options
 [missing-wait-message][]     | 1             |
 [no-browser-sleep][]         | 1             |
 [no-by-xpath][]              | 1             |
+[no-describe-selectors][]    | 1             |
 
 For example, the `missing-perform` rule is enabled by default and will cause
 ESLint to throw an error (with an exit code of `1`) when triggered.
@@ -58,6 +59,7 @@ See [configuring rules][] for more information.
 [missing-wait-message]: docs/rules/missing-wait-message.md
 [no-browser-sleep]: docs/rules/no-browser-sleep.md
 [no-by-xpath]: docs/rules/no-by-xpath.md
+[no-describe-selectors]: docs/rules/no-describe-selectors.md
 [configuring rules]: http://eslint.org/docs/user-guide/configuring#configuring-rules
 
 ## Author

--- a/docs/rules/no-describe-selectors.md
+++ b/docs/rules/no-describe-selectors.md
@@ -1,0 +1,57 @@
+# Discourage nested selectors within describe blocks (no-describe-selectors)
+
+Ensure raw selectors are not used within `describe` blocks.
+
+## Rule details
+
+As described in [Protractor's documentation](https://github.com/angular/protractor/blob/master/docs/page-objects.md), it is recommended that query selectors be organized within Page Objects in order to keep code cleaner, more reusable, and easier to maintain.
+
+Any use of the following patterns are considered warnings:
+
+```js
+describe(function () {
+  // Protractor selectors:
+  element(by.addLocator('newLocator', function () { } ));
+  element(by.binding('something.binding'));
+  element(by.model('something.model'));
+  element(by.buttonText('buttonText'));
+  element(by.partialButtonText('partialButtonText'));
+  element(by.repeater('something in repeater'));
+  element(by.exactRepeater('value in exactRepeater'));
+  element(by.cssContainingText('.css', 'Contained text'));
+  element(by.options('o for o in options'));
+  element(by.deepCss('.deepCss'));
+  element(by.className('className'));
+
+  // Inherited from WebDriver:
+  element(by.css('.css'));
+  element(by.id('id'));
+  element(by.linkText('linkText'));
+  element(by.js('js'));
+  element(by.name('name'));
+  element(by.partialLinkText('partialLinkText'));
+  element(by.tagName('tagName'));
+  element(by.xpath('//xpath'));
+});
+```
+
+The following patterns are not warnings:
+
+```js
+var AngularHomepage = function() {
+  var nameInput = element(by.model('yourName'));
+  var greeting = element(by.binding('yourName'));
+
+  this.get = function() {
+    browser.get('http://www.angularjs.org');
+  };
+
+  this.setName = function(name) {
+    nameInput.sendKeys(name);
+  };
+
+  this.getGreeting = function() {
+    return greeting.getText();
+  };
+};
+```

--- a/index.js
+++ b/index.js
@@ -6,13 +6,15 @@ module.exports = {
     'no-browser-pause': require('./lib/rules/no-browser-pause'),
     'missing-wait-message': require('./lib/rules/missing-wait-message'),
     'no-browser-sleep': require('./lib/rules/no-browser-sleep'),
-    'no-by-xpath': require('./lib/rules/no-by-xpath')
+    'no-by-xpath': require('./lib/rules/no-by-xpath'),
+    'no-describe-selectors': require('./lib/rules/no-describe-selectors')
   },
   rulesConfig: {
     'missing-perform': 2,
     'no-browser-pause': 2,
     'missing-wait-message': 1,
     'no-browser-sleep': 1,
-    'no-by-xpath': 1
+    'no-by-xpath': 1,
+    'no-describe-selectors': 1
   }
 }

--- a/lib/rules/no-describe-selectors.js
+++ b/lib/rules/no-describe-selectors.js
@@ -1,0 +1,25 @@
+'use strict'
+
+/**
+ * @fileoverview Discourage use of selectors within describe blocks.
+ * @author David Adams
+ */
+
+module.exports = function (context) {
+  return {
+    'CallExpression': function (node) {
+      var object = node.callee.object
+
+      if (object && object.name === 'by') {
+        // Use ancestors to determine if 'by' is contained within a describe() block.
+        for (var i = 0; i < context.getAncestors().length; i++) {
+          var parent = context.getAncestors()[i]
+          if (parent.type === 'CallExpression' && parent.callee.name === 'describe') {
+            context.report(node, 'Unexpected selector in describe block')
+            break
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/rules/no-describe-selectors.js
+++ b/test/rules/no-describe-selectors.js
@@ -1,0 +1,129 @@
+'use strict'
+
+/**
+ * @fileoverview Discourage use of selectors within describe blocks.
+ * @author David Adams
+ */
+
+var rule = require('../../lib/rules/no-describe-selectors')
+var RuleTester = require('eslint').RuleTester
+var eslintTester = new RuleTester()
+
+eslintTester.run('no-describe-selectors', rule, {
+  valid: [
+    'var PageObject = function () { this.getDOMElement = function () { return element(by.css(".some-element")); }; }',
+    'module.exports = { getDOMElement: function () { return element(by.css(".some-element")); } };'
+  ],
+
+  invalid: [
+    {
+      code: 'describe(function () { element(by.addLocator("newLocator", function () { } )); })',
+      errors: [{
+        message: 'Unexpected selector in describe block'
+      }]
+    },
+    {
+      code: 'describe(function () {element(by.binding("something.binding")); })',
+      errors: [{
+        message: 'Unexpected selector in describe block'
+      }]
+    },
+    {
+      code: 'describe(function () { element(by.model("something.model")); })',
+      errors: [{
+        message: 'Unexpected selector in describe block'
+      }]
+    },
+    {
+      code: 'describe(function () { element(by.buttonText("buttonText")); })',
+      errors: [{
+        message: 'Unexpected selector in describe block'
+      }]
+    },
+    {
+      code: 'describe(function () { element(by.partialButtonText("partialButtonText")); })',
+      errors: [{
+        message: 'Unexpected selector in describe block'
+      }]
+    },
+    {
+      code: 'describe(function () { element(by.repeater("something in repeater")); })',
+      errors: [{
+        message: 'Unexpected selector in describe block'
+      }]
+    },
+    {
+      code: 'describe(function () { element(by.cssContainingText(".css", "Contained text")); })',
+      errors: [{
+        message: 'Unexpected selector in describe block'
+      }]
+    },
+    {
+      code: 'describe(function () { element(by.options("o for o in options")); })',
+      errors: [{
+        message: 'Unexpected selector in describe block'
+      }]
+    },
+    {
+      code: 'describe(function () { element(by.deepCss(".deepCss")); })',
+      errors: [{
+        message: 'Unexpected selector in describe block'
+      }]
+    },
+    {
+      code: 'describe(function () { element(by.className("className")); })',
+      errors: [{
+        message: 'Unexpected selector in describe block'
+      }]
+    },
+
+    {
+      code: 'describe(function () { element(by.css(".css")); })',
+      errors: [{
+        message: 'Unexpected selector in describe block'
+      }]
+    },
+    {
+      code: 'describe(function () { element(by.id("id")) })',
+      errors: [{
+        message: 'Unexpected selector in describe block'
+      }]
+    },
+    {
+      code: 'describe(function () { element(by.linkText("linkText")) })',
+      errors: [{
+        message: 'Unexpected selector in describe block'
+      }]
+    },
+    {
+      code: 'describe(function () { element(by.js("js")) })',
+      errors: [{
+        message: 'Unexpected selector in describe block'
+      }]
+    },
+    {
+      code: 'describe(function () { element(by.name("name")) })',
+      errors: [{
+        message: 'Unexpected selector in describe block'
+      }]
+    },
+    {
+      code: 'describe(function () { element(by.partialLinkText("partialLinkText")) })',
+      errors: [{
+        message: 'Unexpected selector in describe block'
+      }]
+    },
+    {
+      code: 'describe(function () { element(by.tagName("tagName")) })',
+      errors: [{
+        message: 'Unexpected selector in describe block'
+      }]
+    },
+    {
+      code: 'describe(function () { element(by.xpath("//xpath")) })',
+      errors: [{
+        message: 'Unexpected selector in describe block'
+      }]
+    }
+  ]
+})


### PR DESCRIPTION
Rule to help QA teams everywhere avoid putting lengthy selectors into their `describe(...)` blocks.
