### PR TITLE
Safeguard against null access when using gulp-eslint runner.

### DIFF
--- a/lib/rules/no-angular-classes.js
+++ b/lib/rules/no-angular-classes.js
@@ -21,7 +21,7 @@ module.exports = function (context) {
 
   return {
     'CallExpression': function (node) {
-      if (node.arguments && node.arguments[0].hasOwnProperty('value')) {
+      if (node.arguments && node.arguments.length && node.arguments[0].hasOwnProperty('value')) {
         if (isCSSLocator(node)) {
           for (var i = 0; i < prohibitedClasses.length; i++) {
             if (node.arguments[0].value.indexOf(prohibitedClasses[i]) >= 0) {

--- a/lib/rules/no-angular-classes.js
+++ b/lib/rules/no-angular-classes.js
@@ -21,7 +21,7 @@ module.exports = function (context) {
 
   return {
     'CallExpression': function (node) {
-      if (node.arguments) {
+      if (node.arguments && node.arguments[0].hasOwnProperty('value')) {
         if (isCSSLocator(node)) {
           for (var i = 0; i < prohibitedClasses.length; i++) {
             if (node.arguments[0].value.indexOf(prohibitedClasses[i]) >= 0) {

--- a/lib/rules/use-angular-locators.js
+++ b/lib/rules/use-angular-locators.js
@@ -16,7 +16,7 @@ module.exports = function (context) {
 
   return {
     'CallExpression': function (node) {
-      if (node.arguments) {
+      if (node.arguments && node.arguments[0].hasOwnProperty('value')) {
         if (isCSSLocator(node)) {
           Object.keys(attributeToLocatorMap).forEach(function (key) {
             if (node.arguments[0].value.indexOf(key) >= 0) {

--- a/lib/rules/use-angular-locators.js
+++ b/lib/rules/use-angular-locators.js
@@ -16,7 +16,7 @@ module.exports = function (context) {
 
   return {
     'CallExpression': function (node) {
-      if (node.arguments && node.arguments[0].hasOwnProperty('value')) {
+      if (node.arguments && node.arguments.length && node.arguments[0].hasOwnProperty('value')) {
         if (isCSSLocator(node)) {
           Object.keys(attributeToLocatorMap).forEach(function (key) {
             if (node.arguments[0].value.indexOf(key) >= 0) {


### PR DESCRIPTION
Otherwise can run into the following issue:

```
eslint-plugin-protractor/lib/rules/no-angular-classes.js:27
            if (node.arguments[0].value.indexOf(prohibitedClasses[i]) >= 0) {
                                       ^
TypeError: Cannot read property 'indexOf' of undefined
```
