### PR TITLE
Update require path for ast-utils

### DIFF
--- a/lib/rules/array-callback-return.js
+++ b/lib/rules/array-callback-return.js
@@ -5,7 +5,15 @@
  * @author Alexander Afanasyev (based on Toru Nagashima's work)
  */
 
-var astUtils = require('eslint/lib/ast-utils')
+var astUtils;
+
+try {
+  astUtils = require('eslint/lib/util/ast-utils')
+}
+catch(err) {
+  astUtils = require('eslint/lib/ast-utils')
+}
+
 var isElementArrayFinder = require('../is-element-array-finder')
 
 var TARGET_NODE_TYPE = /^(?:Arrow)?FunctionExpression$/

--- a/lib/rules/array-callback-return.js
+++ b/lib/rules/array-callback-return.js
@@ -5,12 +5,11 @@
  * @author Alexander Afanasyev (based on Toru Nagashima's work)
  */
 
-var astUtils;
+var astUtils
 
 try {
   astUtils = require('eslint/lib/util/ast-utils')
-}
-catch(err) {
+} catch (err) {
   astUtils = require('eslint/lib/ast-utils')
 }
 


### PR DESCRIPTION
In `eslint@5.3` this library is moved into the `util` folder

https://github.com/eslint/eslint/pull/10693/commits/bb35ddee23b7289fcccfec659323c13697d4a3cc