### PR TITLE
fix(rules): fixes eslint-6.x compatibility

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,6 +15,7 @@
             "error",
             "unix"
         ],
+        "no-prototype-builtins": "off",
         "quotes": [
             "error",
             "single"

--- a/lib/rules/array-callback-return.js
+++ b/lib/rules/array-callback-return.js
@@ -5,16 +5,9 @@
  * @author Alexander Afanasyev (based on Toru Nagashima's work)
  */
 
-var astUtils
-
-try {
-  astUtils = require('eslint/lib/util/ast-utils')
-} catch (err) {
-  astUtils = require('eslint/lib/ast-utils')
-}
-
 var isElementArrayFinder = require('../is-element-array-finder')
 
+var ANY_FUNCTION_PATTERN = /^(?:Function(?:Declaration|Expression)|ArrowFunctionExpression)$/
 var TARGET_NODE_TYPE = /^(?:Arrow)?FunctionExpression$/
 var TARGET_METHODS = /^(?:filter|map|reduce)$/
 
@@ -43,6 +36,29 @@ function getLocation (node, sourceCode) {
     return sourceCode.getTokenBefore(node.body)
   }
   return node.id || node
+}
+
+/**
+ * Finds a function node from ancestors of a node.
+ * @param {ASTNode} node - A start node to find.
+ * @returns {Node|null} A found function node.
+ */
+function getUpperFunction (node) {
+  for (var currentNode = node; currentNode; currentNode = currentNode.parent) {
+    if (ANY_FUNCTION_PATTERN.test(currentNode.type)) {
+      return currentNode
+    }
+  }
+  return null
+}
+
+/**
+ * Checks whether or not a node is callee.
+ * @param {ASTNode} node - A node to check.
+ * @returns {boolean} Whether or not the node is callee.
+ */
+function isCallee (node) {
+  return node.parent.type === 'CallExpression' && node.parent.callee === node
 }
 
 /**
@@ -80,9 +96,9 @@ function isCallbackOfArrayMethod (node) {
         break
 
       case 'ReturnStatement':
-        var func = astUtils.getUpperFunction(parent)
+        var func = getUpperFunction(parent)
 
-        if (func === null || !astUtils.isCallee(func)) {
+        if (func === null || !isCallee(func)) {
           return false
         }
         node = func.parent


### PR DESCRIPTION
`ast-utils.js` (from eslint) has changed location once again. In this PR I add support for the updated location. This is possibly not the preferred way, perhaps it would be better to just drop support for older versions or inline the required functions directly in the file?